### PR TITLE
Wav を .NET Core 3.1 に変更

### DIFF
--- a/Wav/Program.cs
+++ b/Wav/Program.cs
@@ -73,6 +73,9 @@ namespace Wav
                 mds = new MDSound.MDSound((uint)SamplingRate, (uint)samplingBuffer, new MDSound.MDSound.Chip[] { chip });
 
 
+#if NETCOREAPP
+                System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+#endif
                 drv = new Driver();
                 ((Driver)drv).Init(
                     args[fnIndex]

--- a/Wav/Properties/AssemblyInfo.cs
+++ b/Wav/Properties/AssemblyInfo.cs
@@ -2,18 +2,6 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// アセンブリに関する一般情報は以下の属性セットをとおして制御されます。
-// 制御されます。アセンブリに関連付けられている情報を変更するには、
-// これらの属性値を変更します。
-[assembly: AssemblyTitle("Wav")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Wav")]
-[assembly: AssemblyCopyright("Copyright ©  2020")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
 // ComVisible を false に設定すると、このアセンブリ内の型は COM コンポーネントから
 // 参照できなくなります。COM からこのアセンブリ内の型にアクセスする必要がある場合は、
 // その型の ComVisible 属性を true に設定します。
@@ -21,16 +9,3 @@ using System.Runtime.InteropServices;
 
 // このプロジェクトが COM に公開される場合、次の GUID が typelib の ID になります
 [assembly: Guid("70f58570-bda0-4b4b-a5dd-a12d055389e3")]
-
-// アセンブリのバージョン情報は次の 4 つの値で構成されています:
-//
-//      メジャー バージョン
-//      マイナー バージョン
-//      ビルド番号
-//      リビジョン
-//
-// すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
-// 既定値にすることができます:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Wav/Wav.csproj
+++ b/Wav/Wav.csproj
@@ -1,36 +1,21 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{70F58570-BDA0-4B4B-A5DD-A12D055389E3}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>mucomDotNET2wav</RootNamespace>
     <AssemblyName>mucomDotNET2wav</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFramework>net472</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Deterministic>true</Deterministic>
+    <AssemblyTitle>Wav</AssemblyTitle>
+    <Product>Wav</Product>
+    <Copyright>Copyright ©  2020</Copyright>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject>Wav.Program</StartupObject>
@@ -42,32 +27,12 @@
     <Reference Include="musicDriverInterface">
       <HintPath>..\lib\musicDriverInterface.dll</HintPath>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="WaveWriter.cs" />
+    <ProjectReference Include="..\mucomDotNETCommon\Common.csproj" />
+    <ProjectReference Include="..\mucomDotNETDriver\Driver.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\mucomDotNETCommon\Common.csproj">
-      <Project>{34aad812-cf44-4080-9be9-1fda164bae55}</Project>
-      <Name>Common</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\mucomDotNETDriver\Driver.csproj">
-      <Project>{8ab04fa5-c36b-44b6-95ef-b0a4dd9b353b}</Project>
-      <Name>Driver</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Wav/Wav.csproj
+++ b/Wav/Wav.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>mucomDotNET2wav</RootNamespace>
     <AssemblyName>mucomDotNET2wav</AssemblyName>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <AssemblyTitle>Wav</AssemblyTitle>
     <Product>Wav</Product>
@@ -21,15 +21,15 @@
     <StartupObject>Wav.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="MDSound">
-      <HintPath>..\..\mml2vgm\mml2vgm\Core\MDSound.dll</HintPath>
+      <HintPath>..\mucomDotNETPlayer\lib\MDSound.dll</HintPath>
     </Reference>
     <Reference Include="musicDriverInterface">
       <HintPath>..\lib\musicDriverInterface.dll</HintPath>
     </Reference>
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\mucomDotNETCommon\Common.csproj" />


### PR DESCRIPTION
合わせて MDSound の参照先を mucomDotNETPlayer\lib\MDSound.dll に変更しています。
MDSound.dll は musicDriverInterface.dll と同じ位置に配置した方がよいかもしれません。