### PR TITLE
MakeMessageDic(string[] lines) の lines = null で実行した後、get で例外が出てしまうのを修正

### DIFF
--- a/mucomDotNETCommon/message.cs
+++ b/mucomDotNETCommon/message.cs
@@ -13,8 +13,7 @@ namespace mucomDotNET.Common
 
         public static void MakeMessageDic(string[] lines)
         {
-            if (lines == null) return;
-            MakeMessageDic(ParseMesseageDicDatas(lines));
+            MakeMessageDic(lines != null ? ParseMesseageDicDatas(lines) : null);
         }
 
         public static void MakeMessageDic(IEnumerable<KeyValuePair<string, string>> datas)


### PR DESCRIPTION
MakeMessageDic(string[] lines) の lines = null の時、 dicMsg が生成されずに結果的に get で例外が出てしまっています。
再現手順としては

1. msg.LoadDefaultMessage の先頭で debug break
2. コピーされた lang 以下のファイルを削除
3. デバッガを再開

ファイルがない場合は MakeMessageDic(new string[] {}) を呼んでおくと回避できます。