### PR TITLE
メッセージ文字列の整形を get 時に毎回行うのではなく、ファイル読み込み時に行うようにした

### DIFF
--- a/mucomDotNETCommon/message.cs
+++ b/mucomDotNETCommon/message.cs
@@ -34,12 +34,8 @@ namespace mucomDotNET.Common
         {
             if (dicMsg == null) LoadDefaultMessage();
 
-            if (dicMsg.ContainsKey(code))
-            {
-                return dicMsg[code].Replace("\\r", "\r").Replace("\\n", "\n");
-            }
-
-            return string.Format("<no message>({0})", code);
+            string ret;
+            return dicMsg.TryGetValue(code, out ret) ? ret : string.Format("<no message>({0})", code);
         }
 
         /// <summary>
@@ -69,7 +65,7 @@ namespace mucomDotNET.Common
                     if (str[0] == ';') continue;
                     code = str.Substring(0, str.IndexOf("=")).Trim();
                     msg = str.Substring(str.IndexOf("=") + 1, str.Length - str.IndexOf("=") - 1);
-
+                    msg = msg.Replace("\\r", "\r").Replace("\\n", "\n");
                 }
                 catch
                 {


### PR DESCRIPTION
* get は高頻度に呼ばれると思いますが、結果が変わらない置換処理を毎回実行するのは効率がよくないと思います
* "\r" や "\n" といった文字列が入れられなくなります (実際そんなことあるかと言われるとないとは思いますが・・・)